### PR TITLE
Remove restriction for no more than 4 fitting parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ esr_env
 #ESR
 build/
 docs/build/
+
+examples/fitting/
+examples/data.txt

--- a/esr/fitting/fit_single.py
+++ b/esr/fitting/fit_single.py
@@ -40,13 +40,14 @@ def single_function(labels, basis_functions, likelihood, pmin=0, pmax=5, tmax=5,
                             tmax,
                             pmin,
                             pmax,
-                            try_integration=try_integration)
+                            try_integration=try_integration,
+                            max_param=max_param)
 
     # (3) Obtain the Fisher matrix for this function
     fcn, eq, integrated = likelihood.run_sympify(fstr,
                                             tmax=tmax, 
                                             try_integration=try_integration)
-    params, negloglike, deriv, codelen = convert_params(fcn, eq, integrated, params, likelihood, chi2) 
+    params, negloglike, deriv, codelen = convert_params(fcn, eq, integrated, params, likelihood, chi2, max_param=max_param)
     if verbose:
         print('theta_ML:', params)
         print('Residuals:', negloglike, chi2)

--- a/esr/fitting/test_all.py
+++ b/esr/fitting/test_all.py
@@ -5,6 +5,7 @@ import os
 import sys
 from mpi4py import MPI
 from scipy.optimize import minimize
+import itertools
 
 from esr.fitting.sympy_symbols import *
 import esr.generation.simplifier as simplifier
@@ -65,12 +66,8 @@ def get_functions(comp, likelihood, unique=True):
     else:
         unifn_file = likelihood.fn_dir + "/compl_%i/all_equations_%i.txt"%(comp,comp)
     
-    if comp==8:
-        sys.setrecursionlimit(2000)
-    elif comp==9:
-        sys.setrecursionlimit(2500)
-    elif comp==10:
-        sys.setrecursionlimit(3000)
+    if comp>=8:
+        sys.setrecursionlimit(2000 + 500 * (comp - 8))
 
     if rank == 0:
         for dirname in [likelihood.base_out_dir, likelihood.out_dir, likelihood.temp_dir]:
@@ -105,7 +102,7 @@ def get_functions(comp, likelihood, unique=True):
     return fcn_list[data_start:data_end], data_start, data_end
     
     
-def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log_opt=False):
+def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log_opt=False, max_param=4):
     """Optimise the parameters of a function to fit data
     
     Args:
@@ -116,6 +113,7 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log
         :pmax (float): maximum value for each parameter to consider when generating initial guess
         :try_integration (bool, default=False): when likelihood requires integral, whether to try to analytically integrate (True) or just numerically integrate (False)
         :log_opt (bool, default=False): whether to optimise 1 and 2 parameter cases in log space
+        :max_param (int, default=4): The maximum number of parameters considered. This sets the shapes of arrays used.
         
     Returns:
         :chi2_i (float): the minimum value of -log(likelihood) (corresponding to the maximum likelihood)
@@ -125,10 +123,11 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log
 
     xvar, yvar = likelihood.xvar, likelihood.yvar
 
-    Niter_1, Niter_2, Niter_3, Niter_4 = 30, 30, 30, 30
-    Nconv_1, Nconv_2, Nconv_3, Nconv_4 = 5, 5, 5, 5
-
-    params = np.zeros(4)
+    Niter = 30
+    Nconv = 5
+    
+    nparam = simplifier.get_max_param([fcn_i], verbose=False)
+    params = np.zeros(max_param)
     
     try:
         fcn_i, eq, integrated = likelihood.run_sympify(fcn_i, tmax=tmax, try_integration=try_integration)
@@ -140,56 +139,42 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log
             return chi2_i, params
 
         flag_three = False
-        if ("a3" in fcn_i) and ("a2" in fcn_i) and ("a1" in fcn_i) and ("a0" in fcn_i):
-            Niter = Niter_4
-            Nconv = Nconv_4
-            flag_three = True           # In this case we don't have any mult_param
 
-            eq_numpy = sympy.lambdify([x, a0, a1, a2, a3], eq, modules=["numpy"])
-            if np.sum(np.isnan(eq_numpy(xvar,1,1,1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,1,1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,1,-1,1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,1,1,-1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,-1,1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,1,-1,1)))>0  and np.sum(np.isnan(eq_numpy(xvar,1,-1,-1,1)))>0  and np.sum(np.isnan(eq_numpy(xvar,-1,-1,-1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,1,1,1,-1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,1,1,-1)))>0 and np.sum(np.isnan(eq_numpy(xvar,1,-1,1,-1)))>0 and np.sum(np.isnan(eq_numpy(xvar,1,1,-1,-1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,-1,1,-1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,1,-1,-1)))>0  and np.sum(np.isnan(eq_numpy(xvar,1,-1,-1,-1)))>0  and np.sum(np.isnan(eq_numpy(xvar,-1,-1,-1,-1)))>0:
-                chi2_i = np.inf            # Don't bother trying to optimise bc this fcn is clearly really bad
-                return chi2_i, params
-                
-        elif ("a2" in fcn_i) and ("a1" in fcn_i) and ("a0" in fcn_i):
-            Niter = Niter_3
-            Nconv = Nconv_3
-            flag_three = True           # In this case we don't have any mult_param
-            eq_numpy = sympy.lambdify([x, a0, a1, a2], eq, modules=["numpy"])
-            if np.sum(np.isnan(eq_numpy(xvar,1,1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,1,-1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,1,1,-1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,-1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,1,-1)))>0  and np.sum(np.isnan(eq_numpy(xvar,1,-1,-1)))>0  and np.sum(np.isnan(eq_numpy(xvar,-1,-1,-1)))>0:
-                chi2_i = np.inf            # Don't bother trying to optimise bc this fcn is clearly really bad
-                return chi2_i, params
-                
-        elif ("a1" in fcn_i) and ("a0" in fcn_i):
-            Niter = Niter_2
-            Nconv = Nconv_2
-            eq_numpy = sympy.lambdify([x, a0, a1], eq, modules=["numpy"])
-            if np.sum(np.isnan(eq_numpy(xvar,1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,1,-1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1,-1)))>0:
-                chi2_i = np.inf
-                return chi2_i, params
-
-        else:
-            Niter = Niter_1
-            Nconv = Nconv_1
-            eq_numpy = sympy.lambdify([x, a0], eq, modules=["numpy"])
-            if np.sum(np.isnan(eq_numpy(xvar,1)))>0 and np.sum(np.isnan(eq_numpy(xvar,-1)))>0:
-                chi2_i = np.inf
-                return chi2_i, params
-
-        chi2_min = np.inf            # Reset chi2 for this fcn to make sure that every attempt at minimisation improves on this
-
-        mult_arr = np.array([1,1,1,1])
+        mult_arr = np.ones(max_param)
         count_lowest = 0
         inf_count = 0
         exception_count = 0
         
+        if nparam > 1:
+            all_a = ' '.join([f'a{i}' for i in range(nparam)])
+            all_a = list(sympy.symbols(all_a, real=True))
+            eq_numpy = sympy.lambdify([x] + all_a, eq, modules=["numpy"])
+        else:
+            eq_numpy = sympy.lambdify([x, a0], eq, modules=["numpy"])
+    
+        bad_fun = True
+        for p in itertools.product([1, -1], repeat=nparam):
+            if not (np.sum(np.isnan(eq_numpy(xvar,*p)))>0):
+                bad_fun = False
+                break
+        
+        if bad_fun:
+            # Don't bother trying to optimise bc this fcn is clearly really bad
+            chi2_i = np.inf
+            return chi2_i, params
+            
+        # Reset chi2
+        chi2_min = np.inf
+            
+        if nparam > 2:
+            flag_three = True
+        
         for j in range(Niter):
-            if ("a3" in fcn_i) and ("a2" in fcn_i) and ("a1" in fcn_i) and ("a0" in fcn_i):
-                inpt = [np.random.uniform(pmin,pmax), np.random.uniform(pmin,pmax), np.random.uniform(pmin,pmax), np.random.uniform(pmin,pmax)]
+        
+            if nparam > 2:
+                inpt = [np.random.uniform(pmin,pmax) for _ in range(nparam)]
                 res = minimize(chi2_fcn, inpt, args=(likelihood, eq_numpy, integrated, None), method="BFGS", options={'maxiter': 7000})    # Default=3000
-            elif ("a2" in fcn_i) and ("a1" in fcn_i) and ("a0" in fcn_i):
-                inpt = [np.random.uniform(pmin,pmax), np.random.uniform(pmin,pmax), np.random.uniform(pmin,pmax)]      # Larger range bc linear search here
-                res = minimize(chi2_fcn, inpt, args=(likelihood, eq_numpy, integrated, None), method="BFGS", options={'maxiter': 5000})    # Default=3000
-            elif ("a1" in fcn_i) and ("a0" in fcn_i):
+            elif nparam == 2:
                 if log_opt:
                     inpt = [np.random.uniform(pmin,pmax), np.random.uniform(pmin,pmax)]           # These are now in log-space, so this is 1e-1 -- 1e1; was -10:10
                     res_pp = minimize(chi2_fcn, inpt, args=(likelihood, eq_numpy, integrated, ['+','+']), method="BFGS")
@@ -198,18 +183,19 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log
                     res_mm = minimize(chi2_fcn, inpt, args=(likelihood, eq_numpy, integrated, ['-','-']), method="BFGS")
                 
                     choose = np.argmin([res_pp['fun'], res_mp['fun'], res_pm['fun'], res_mm['fun']])
+                    mult_arr = np.one(max_param)
                     if choose==0:
                         res = res_pp
-                        mult_arr = np.array([1,1,1,1])
                     elif choose==1:
                         res = res_mp
-                        mult_arr = np.array([-1,1,1,1])
+                        mult_arr[0] = -1
                     elif choose==2:
                         res = res_pm
-                        mult_arr = np.array([1,-1,1,1])
+                        mult_arr[1] = -1
                     elif choose==3:
                         res = res_mm
-                        mult_arr = np.array([-1,-1,1,1])
+                        mult_arr[0] = -1
+                        mult_arr[1] = -1
                     else:
                         print("Some ambiguity in choose", eq, flush=True)
                         res = res_pp
@@ -224,48 +210,54 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log
                     res_p = minimize(chi2_fcn, inpt, args=(likelihood, eq_numpy, integrated, ['+']), method="BFGS")
                     res_m = minimize(chi2_fcn, inpt, args=(likelihood, eq_numpy, integrated, ['-']), method="BFGS")
 
+                    mult_arr = np.one(max_param)
                     if res_p['fun']<res_m['fun']:
                         res = res_p
-                        mult_arr = np.array([1,1,1,1])
                     elif res_p['fun']>res_m['fun']:
                         res = res_m
-                        mult_arr = np.array([-1,1,1,1])
+                        mult_arr[0] = -1
                     else:
-                        res = res_p     # Arbitrarily decide to take the +ve in cases where they're the same, but don't update mult_arr
+                        # Both give same. Choose positive (arbitrarily)
+                        res = res_p
                 else:
                     flag_three = True
                     inpt = np.random.uniform(pmin,pmax)
-                    res = minimize(chi2_fcn, inpt, args=(likelihood, eq_numpy, integrated, None), method="BFGS", options={'maxiter': 5000})    # Default=3000
+                    res = minimize(chi2_fcn, inpt, args=(likelihood, eq_numpy, integrated, None), method="BFGS", options={'maxiter': 5000})
 
             if np.isinf(res['fun']):
                 inf_count += 1
 
-            if inf_count==50 and np.isinf(chi2_min):        # If you get inf all of the first 50 times, consider this a failure
+            # Failure if first 50 all give inf
+            if inf_count==50 and np.isinf(chi2_min):
                 break
 
-            if res['fun']-chi2_min < -2.:     # negloglike has got better by 2, so reset the count to 0
+            # Reset count if log-like improves by 2
+            if res['fun']-chi2_min < -2.:
                 count_lowest=0
 
-            if abs(res['fun']-chi2_min) < 0.5:  # If we've ended up within 0.5 of the best value we say this run has converged to that
+            # If within 0.5 of lowest, say converged to that value
+            if abs(res['fun']-chi2_min) < 0.5:
                 count_lowest += 1
 
             if res['fun'] < chi2_min:
                 best = res
-                mult_arr_best = mult_arr        # If you're looking at 3 params this is just [1,1,1]
+                mult_arr_best = mult_arr
                 chi2_min = res['fun']
 
-            # We've converged the required number of times, so we call this a success
+            # Converged the required number of times, so a success
             if count_lowest==Nconv:
                 break
 
-            
-        if chi2_min < 1.e100:            # This means that some optimisation has happened, so we have something to print for params
+        if chi2_min < 1.e100:
+            # Optimisation happened. Print something
             if flag_three:
-                params = np.pad(np.array(best.x), (0, 4-len(best.x)))       # Params go in directly
+                params = np.pad(np.array(best.x), (0, max_param-len(best.x)))
             else:
-                params = np.pad(10.**np.array(best.x), (0, 4-len(best.x))) * mult_arr_best      # Params put in linear space and sign added back in
-                        
-        chi2_i = chi2_min       # This is after all the iterations, so it's the best we have; reduced chi2
+                # Params put in linear space and sign added back in
+                params = np.pad(10.**np.array(best.x), (0, max_param-len(best.x))) * mult_arr_best
+                 
+        # This is after all the iterations, so it's the best we have; reduced chi2
+        chi2_i = chi2_min
 
     except NameError:
         print(NameError)
@@ -277,9 +269,9 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log
         try:
             if chi2_min < 1.e100:
                 if flag_three:
-                    params = np.pad(np.array(best.x), (0, 4-len(best.x)))   
+                    params = np.pad(np.array(best.x), (0, max_param-len(best.x)))
                 else:
-                    params = np.pad(10.**np.array(best.x), (0, 4-len(best.x))) * mult_arr_best
+                    params = np.pad(10.**np.array(best.x), (0, max_param-len(best.x))) * mult_arr_best
                 chi2_i = chi2_min
             else:
                 chi2_i = np.nan
@@ -287,7 +279,7 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log
         except:
             chi2_i = np.nan
             params[:] = 0.
-    
+
     except Exception as e:
         print(e)
         return np.nan, params

--- a/esr/fitting/test_all_Fisher.py
+++ b/esr/fitting/test_all_Fisher.py
@@ -11,6 +11,7 @@ import numdifftools as nd
 
 import esr.fitting.test_all as test_all
 from esr.fitting.sympy_symbols import *
+import esr.generation.simplifier as simplifier
 
 warnings.filterwarnings("ignore")
 
@@ -54,7 +55,7 @@ def load_loglike(comp, likelihood, data_start, data_end, split=True):
     return negloglike, param1, param2, param3, param4
 
 
-def convert_params(fcn_i, eq, integrated, theta_ML, likelihood, negloglike):
+def convert_params(fcn_i, eq, integrated, theta_ML, likelihood, negloglike, max_param=4):
     """Compute Fisher, correct MLP and find parametric contirbution to description length for single function
     
     Args:
@@ -64,6 +65,7 @@ def convert_params(fcn_i, eq, integrated, theta_ML, likelihood, negloglike):
         :theta_ML (list): the maximum likelihood values of the parameters
         :likelihood (fitting.likelihood object): object containing data, likelihood functions and file paths
         :negloglike (float): the minimum log-likelihood for this function
+        :max_param (int, default=4): The maximum number of parameters considered. This sets the shapes of arrays used.
     
     Returns:
         :params (list): the corrected maximum likelihood values of the parameters
@@ -73,196 +75,83 @@ def convert_params(fcn_i, eq, integrated, theta_ML, likelihood, negloglike):
         
     """
 
-    def f4(x):
-        return likelihood.negloglike(x,eq_numpy, integrated=integrated)
-
-    def f3(x):
-        return likelihood.negloglike(x,eq_numpy, integrated=integrated)
-
-    def f2(x):
-        return likelihood.negloglike(x,eq_numpy, integrated=integrated)
-
-    def f1(x):
-        return likelihood.negloglike([x],eq_numpy, integrated=integrated)
-
-    params = np.zeros(4)
-    deriv = np.zeros(10)
+    nparam = simplifier.get_max_param([fcn_i], verbose=False)
     
+    if nparam > 0:
+        def fop(x):
+            return likelihood.negloglike(x,eq_numpy, integrated=integrated)
+    else:
+        def fop(x):
+            return likelihood.negloglike([x],eq_numpy, integrated=integrated)
+
+    params = np.zeros(nparam)
+    deriv = np.full(int(max_param * (max_param + 1) / 2), np.nan)
+
+    # Step-sizes to try in case the function misbehvaes
     d_list = [1.e-5, 10.**(-5.5), 10.**(-4.5), 1.e-6, 1.e-4, 10.**(-6.5), 10.**(-3.5), 1.e-7, 1.e-3, 10.**(-7.5), 10.**(-2.5), 1.e-8, 1.e-2, 1.e-9, 1.e-10, 1.e-11]
+    
     method_list = ["central", "forward", "backward"]
 
-    if ("a3" in fcn_i) and ("a2" in fcn_i) and ("a1" in fcn_i) and ("a0" in fcn_i):
-        k=4
-    
-        try:
-            eq_numpy = sympy.lambdify([x, a0, a1, a2, a3], eq, modules=["numpy"])
-        except Exception:
-            print("BAD:", fcn_i, negloglike, np.isfinite(negloglike))
-            Fisher_diag = np.nan
-            deriv[:] = np.array([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan])
-            return params, negloglike, deriv, codelen
-    
-        Hfun = nd.Hessian(f4)
-        Hmat = Hfun(theta_ML)
-    
-        Fisher_diag = np.array([Hmat[0,0], Hmat[1,1], Hmat[2,2], Hmat[3,3]])                # 2nd derivatives of -log(L) wrt params
-    
-        deriv[:] = np.array([Hmat[0,0], Hmat[0,1], Hmat[0,2], Hmat[0,3], Hmat[1,1], Hmat[1,2], Hmat[1,3], Hmat[2,2], Hmat[2,3], Hmat[3,3]])
-    
-        Delta = np.sqrt(12./Fisher_diag)
-        Nsteps = abs(np.array(theta_ML))/Delta
-    
-        if (np.sum(Fisher_diag <= 0.) > 0.) or (np.sum(np.isnan(Fisher_diag)) > 0) or (np.sum(np.isinf(Fisher_diag)) > 0) or (np.sum(Nsteps<1) > 0):
-            for d2, meth in itertools.product(d_list, method_list):
-                if use_relative_dx:
-                    Hfun = nd.Hessian(f4, step = np.abs(d2*theta_ML)+1.e-15, method=meth)          # Step is array, one for each param
-                else:
-                    Hfun = nd.Hessian(f4, step = d2, method=meth)
-                Hmat = Hfun(theta_ML)
-                Fisher_diag_tmp = np.array([Hmat[0,0], Hmat[1,1], Hmat[2,2], Hmat[3,3]])
-                Delta_tmp = np.sqrt(12./Fisher_diag_tmp)
-                Nsteps_tmp = abs(np.array(theta_ML))/Delta_tmp
-                if (np.sum(Fisher_diag_tmp <= 0.) <= 0) and (np.sum(np.isnan(Fisher_diag_tmp)) <= 0) and (np.sum(np.isinf(Fisher_diag)) <= 0) and (np.sum(Nsteps_tmp<1)<=0):
-                    if negloglike<0.:
-                        print("Succeeded at rectifying Fisher:", fcn_i, d2, meth, Fisher_diag_tmp, theta_ML, Delta_tmp, Nsteps_tmp, flush=True)
-                    Fisher_diag = Fisher_diag_tmp
-                    Delta, Nsteps = Delta_tmp, Nsteps_tmp
-                    deriv[:] = np.array([Hmat[0,0], Hmat[0,1], Hmat[0,2], Hmat[0,3], Hmat[1,1], Hmat[1,2], Hmat[1,3], Hmat[2,2], Hmat[2,3], Hmat[3,3]])
-                    break
-    
-    elif ("a2" in fcn_i) and ("a1" in fcn_i) and ("a0" in fcn_i):
-        k=3
-    
-        theta_ML = theta_ML[:-1]            # Only keep as many params as we have for this fcn
-    
-        try:
-            eq_numpy = sympy.lambdify([x, a0, a1, a2], eq, modules=["numpy"])
-        except Exception:
-            print("BAD:", fcn_i, negloglike, np.isfinite(negloglike))
-            Fisher_diag = np.nan
-            deriv[:] = np.array([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan])
-            return params, negloglike, deriv, codelen
-    
-        Hfun = nd.Hessian(f3)
-        Hmat = Hfun(theta_ML)
-    
-        Fisher_diag = np.array([Hmat[0,0], Hmat[1,1], Hmat[2,2]])
-    
-        deriv[:] = np.array([Hmat[0,0], Hmat[0,1], Hmat[0,2], np.nan, Hmat[1,1], Hmat[1,2], np.nan, Hmat[2,2], np.nan, np.nan])
-    
-        Delta = np.sqrt(12./Fisher_diag)
-        Nsteps = abs(np.array(theta_ML))/Delta
-    
-        if (np.sum(Fisher_diag <= 0.) > 0.) or (np.sum(np.isnan(Fisher_diag)) > 0) or (np.sum(np.isinf(Fisher_diag)) > 0) or (np.sum(Nsteps<1) > 0):
-            for d2, meth in itertools.product(d_list, method_list):
-                if use_relative_dx:
-                    Hfun = nd.Hessian(f3, step = np.abs(d2*theta_ML)+1.e-15, method=meth)
-                else:
-                    Hfun = nd.Hessian(f3, step = d2, method=meth)
-                Hmat = Hfun(theta_ML)
-                Fisher_diag_tmp = np.array([Hmat[0,0], Hmat[1,1], Hmat[2,2]])
-                Delta_tmp = np.sqrt(12./Fisher_diag_tmp)
-                Nsteps_tmp = abs(np.array(theta_ML))/Delta_tmp
-                if (np.sum(Fisher_diag_tmp <= 0.) <= 0) and (np.sum(np.isnan(Fisher_diag_tmp)) <= 0) and (np.sum(np.isinf(Fisher_diag)) <= 0) and (np.sum(Nsteps_tmp<1)<=0):
-                    if negloglike<0.:
-                        print("Succeeded at rectifying Fisher:", fcn_i, d2, meth, Fisher_diag_tmp, theta_ML, Delta_tmp, Nsteps_tmp, flush=True)
-                    Fisher_diag = Fisher_diag_tmp
-                    Delta, Nsteps = Delta_tmp, Nsteps_tmp
-                    deriv[:] = np.array([Hmat[0,0], Hmat[0,1], Hmat[0,2], np.nan, Hmat[1,1], Hmat[1,2], np.nan, Hmat[2,2], np.nan, np.nan])
-                    break
-    
-    elif ("a1" in fcn_i) and ("a0" in fcn_i):
-        k=2
-    
-        theta_ML = theta_ML[:-2]
-    
-        try:
-            eq_numpy = sympy.lambdify([x, a0, a1], eq, modules=["numpy"])
-        except Exception:
-            print("BAD:", fcn_i, negloglike, np.isfinite(negloglike))
-            Fisher_diag = np.nan
-            deriv[:] = np.array([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan])
-            return params, negloglike, deriv, codelen
-        
-        Hfun = nd.Hessian(f2)                       # Calculate the fcn in general
-        Hmat = Hfun(theta_ML)       # Evaluate it at the ML point
-    
-        Fisher_diag = np.array([Hmat[0,0], Hmat[1,1]])
-    
-        deriv[:] = np.array([Hmat[0,0], Hmat[0,1], np.nan, np.nan, Hmat[1,1], np.nan, np.nan, np.nan, np.nan, np.nan])
-        
-        Delta = np.sqrt(12./Fisher_diag)
-        Nsteps = abs(np.array(theta_ML))/Delta
-
-        if (np.sum(Fisher_diag <= 0.) > 0.) or (np.sum(np.isnan(Fisher_diag)) > 0) or (np.sum(np.isinf(Fisher_diag)) > 0) or (np.sum(Nsteps<1) > 0):
-            for d2, meth in itertools.product(d_list, method_list):
-                if use_relative_dx:
-                    Hfun = nd.Hessian(f2, step = np.abs(d2*theta_ML)+1.e-15, method=meth)
-                else:
-                    Hfun = nd.Hessian(f2, step = d2, method=meth)
-                Hmat = Hfun(theta_ML)
-                Fisher_diag_tmp = np.array([Hmat[0,0], Hmat[1,1]])
-                Delta_tmp = np.sqrt(12./Fisher_diag_tmp)
-                Nsteps_tmp = abs(np.array(theta_ML))/Delta_tmp
-                if (np.sum(Fisher_diag_tmp <= 0.) <= 0) and (np.sum(np.isnan(Fisher_diag_tmp)) <= 0) and (np.sum(np.isinf(Fisher_diag)) <= 0) and (np.sum(Nsteps_tmp<1)<=0):
-                    if negloglike<0.:
-                        print("Succeeded at rectifying Fisher:", fcn_i, d2, meth, Fisher_diag_tmp, theta_ML, Delta_tmp, Nsteps_tmp, flush=True)
-                    Fisher_diag = Fisher_diag_tmp
-                    Delta, Nsteps = Delta_tmp, Nsteps_tmp
-                    deriv[:] = np.array([Hmat[0,0], Hmat[0,1], np.nan, np.nan, Hmat[1,1], np.nan, np.nan, np.nan, np.nan, np.nan])
-                    break
-
-    elif ("a0" in fcn_i):
-        k=1
-        
-        theta_ML = theta_ML[:-3]            # Only keep as many params as we have for this fcn
-        
-        try:
-            eq_numpy = sympy.lambdify([x, a0], eq, modules=["numpy"])
-        except Exception:
-            print("BAD:", fcn_i, negloglike, np.isfinite(negloglike))
-            Fisher_diag = np.nan
-            deriv[:] = np.array([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan])
-            return params, negloglike, deriv, codelen
-        
-        Hfun = nd.Hessian(f1)
-        Hmat = Hfun(theta_ML)
-    
-        Fisher_diag = Hmat[0,0]
-    
-        deriv[:] = np.array([Hmat[0,0], np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan])
-    
-        Delta = np.sqrt(12./Fisher_diag)
-        Nsteps = abs(np.array(theta_ML))/Delta
-    
-        if (np.sum(Fisher_diag <= 0.) > 0) or (np.sum(np.isnan(Fisher_diag)) > 0) or (np.sum(np.isinf(Fisher_diag)) > 0) or (np.sum(Nsteps<1) > 0):
-            for d2, meth in itertools.product(d_list, method_list):
-                if use_relative_dx:
-                    Hfun = nd.Hessian(f1, step = np.abs(d2*theta_ML)+1.e-15, method=meth)
-                else:
-                    Hfun = nd.Hessian(f1, step = d2, method=meth)
-                Hmat = Hfun(theta_ML)
-                Fisher_diag_tmp = Hmat[0,0]
-                Delta_tmp = np.sqrt(12./Fisher_diag_tmp)
-                Nsteps_tmp = abs(np.array(theta_ML))/Delta_tmp
-                if (np.sum(Fisher_diag_tmp <= 0.) <= 0) and (np.sum(np.isnan(Fisher_diag_tmp)) <= 0) and (np.sum(np.isinf(Fisher_diag)) <= 0) and (np.sum(Nsteps_tmp<1)<=0):
-                    if negloglike<0.:
-                        print("Succeeded at rectifying Fisher:", fcn_i, d2, meth, Fisher_diag_tmp, theta_ML, Delta_tmp, Nsteps_tmp, flush=True)
-                    Fisher_diag = Fisher_diag_tmp
-                    Delta, Nsteps = Delta_tmp, Nsteps_tmp
-                    deriv[:] = np.array([Hmat[0,0], np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan])
-                    break
-    
-    else:                   # No params
+    if nparam == 0:
         codelen = 0
         return params, negloglike, deriv, codelen
 
+    try:
+        if nparam > 1:
+            all_a = ' '.join([f'a{i}' for i in range(nparam)])
+            all_a = list(sympy.symbols(all_a, real=True))
+            eq_numpy = sympy.lambdify([x] + all_a, eq, modules=["numpy"])
+        else:
+            eq_numpy = sympy.lambdify([x, a0], eq, modules=["numpy"])
+    except Exception:
+        print("BAD:", fcn_i, negloglike, np.isfinite(negloglike))
+        Fisher_diag = np.nan
+        deriv[:] = np.nan
+        return params, negloglike, deriv, codelen
+    
+    # Get Hessian
+    theta_ML = theta_ML[:nparam]
+    Hfun = nd.Hessian(fop)
+    Hmat = Hfun(theta_ML)
+    
+    # 2nd derivatives of -log(L) wrt params
+    Fisher_diag = np.array([Hmat[i,i] for i in range(nparam)])
+    
+    # Precision to know constants
+    Delta = np.sqrt(12./Fisher_diag)
+    Nsteps = abs(np.array(theta_ML))/Delta
+    
+    for i in range(nparam):
+        start = int(i * max_param - (i - 1) * i / 2)
+        deriv[start:start+nparam-i] = Hmat[i,i:]
+    
+    if (np.sum(Fisher_diag <= 0.) > 0.) or (np.sum(np.isnan(Fisher_diag)) > 0) or (np.sum(np.isinf(Fisher_diag)) > 0) or (np.sum(Nsteps<1) > 0):
+        for d2, meth in itertools.product(d_list, method_list):
+            if use_relative_dx:
+                Hfun = nd.Hessian(fop, step=np.abs(d2*theta_ML)+1.e-15, method=meth)
+            else:
+                Hfun = nd.Hessian(fop, step = d2, method=meth)
+            Hmat = Hfun(theta_ML)
+            Fisher_diag_tmp = np.array([Hmat[i,i] for i in range(nparam)])
+            Delta_tmp = np.sqrt(12./Fisher_diag_tmp)
+            Nsteps_tmp = abs(np.array(theta_ML))/Delta_tmp
+            
+            if (np.sum(Fisher_diag_tmp <= 0.) <= 0) and (np.sum(np.isnan(Fisher_diag_tmp)) <= 0) and (np.sum(np.isinf(Fisher_diag)) <= 0) and (np.sum(Nsteps_tmp<1)<=0):
+                print("Succeeded at rectifying Fisher:", fcn_i, d2, meth, Fisher_diag_tmp, theta_ML, Delta_tmp, Nsteps_tmp, flush=True)
+                Fisher_diag = Fisher_diag_tmp
+                Delta, Nsteps = Delta_tmp, Nsteps_tmp
+                start = int(i * max_param - (i - 1) * i / 2)
+                deriv[start:start+nparam-i] = Hmat[i,i:]
+                break
+                
     # Must indicate a bad fcn, so just need to make sure it doesn't have a good -log(L)
     if (np.sum(Fisher_diag <= 0.) > 0.) or (np.sum(np.isnan(Fisher_diag)) > 0):
         if negloglike<0.:
             print("ATTENTION, a relatively good function has Fisher element negative, zero or nan: ", fcn_i, negloglike, Fisher_diag, flush=True)
         codelen = np.nan
         return params, negloglike, deriv, codelen
+    
+    k = nparam
 
     if np.sum(Nsteps<1)>0:         # Possibly should reevaluate -log(L) with the param(s) set to 0, but doesn't matter unless the fcn is a very good one
         if negloglike<-1500.:
@@ -272,19 +161,15 @@ def convert_params(fcn_i, eq, integrated, theta_ML, likelihood, negloglike):
         
         negloglike_orig = np.copy(negloglike)
         
-        if k==1:
-            negloglike = f1(theta_ML)                    # Modified here but if this doesn't happen they stay the same
-        elif k==2:
-            negloglike = f2(theta_ML)       # All params still here, just some of them might be 0
-        elif k==3:
-            negloglike = f3(theta_ML)
-        elif k==4:
-            negloglike = f4(theta_ML)
+        # See new value with theta = 0
+        negloglike = fop(theta_ML)
             
-        if negloglike_orig<-1500.:          # Should be exactly the same condition as the above
+        # Should be exactly the same condition as the above
+        if negloglike_orig<-1500.:
             print("negloglikes:", negloglike_orig, negloglike, flush=True)
 
-        k -= np.sum(Nsteps<1)       # For the codelen, we effectively don't have the parameter that had Nsteps<1
+        # For the codelen, we effectively don't have the parameter that had Nsteps<1
+        k -= np.sum(Nsteps<1)
             
         if k<0:
             print("This shouldn't have happened", flush=True)
@@ -298,7 +183,8 @@ def convert_params(fcn_i, eq, integrated, theta_ML, likelihood, negloglike):
     
     codelen = -k/2.*math.log(3.) + np.sum( 0.5*np.log(Fisher_diag) + np.log(abs(np.array(theta_ML))) )
 
-    params[:] = np.pad(theta_ML, (0, 4-len(theta_ML)))            # New params after the setting to 0, padded to length 4 as always
+    # New params after the setting to 0, padded to length max_param as always
+    params[:] = np.pad(theta_ML, (0, max_param-len(theta_ML)))
 
     if (np.isinf(codelen) or codelen>200.) and negloglike<-1500.:
         print("ATTENTION, a relative good function has a very big codelength:", fcn_i, k, Fisher_diag, theta_ML, Delta, Nsteps, negloglike, codelen, flush=True)

--- a/esr/generation/duplicate_checker.py
+++ b/esr/generation/duplicate_checker.py
@@ -269,6 +269,9 @@ def main(runname, compl, track_memory=False, search_tmax=60, expand_tmax=1, seed
         print('\nChecking Results', flush=True)
     if compl > 2:
         simplifier.check_results(dirname, compl)
+        
+    sys.stdout.flush()
+    comm.Barrier()
 
     return
 

--- a/esr/generation/simplifier.py
+++ b/esr/generation/simplifier.py
@@ -1259,13 +1259,18 @@ def load_subs(fname, max_param, use_sympy=True, bcast_res=True):
                 all_subs[i][j] = dict(zip(k, v))
                 if not use_sympy:
                     all_subs[i][j] = str(all_subs[i][j])
-                
+    comm.Barrier()
+    
     all_subs = comm.gather(all_subs, root=0)
+    
     if rank == 0:
         all_subs = list(itertools.chain(*all_subs))
     if bcast_res:
         all_subs = comm.bcast(all_subs, root=0)
-    
+        # Fix MPI4PY bug for empty lists
+        if isinstance(all_subs, int):
+            all_subs = [[] for _ in range(all_subs)]
+
     return all_subs
     
 

--- a/esr/plotting/plot.py
+++ b/esr/plotting/plot.py
@@ -19,6 +19,7 @@ def pareto_plot(dirname, savename, do_DL=True, do_logL=True):
 
     all_f = os.listdir(dirname)
     all_f = [f for f in all_f if f.startswith('final_')]
+    print(all_f)
     all_comp = [int(f[len('final_'):-len('.dat')]) for f in all_f]
     all_logL = np.empty(len(all_comp))
     all_DL = np.empty(len(all_comp))

--- a/examples/docs_examples.py
+++ b/examples/docs_examples.py
@@ -1,0 +1,137 @@
+# Copyright 2023 Deaglan J. Bartlett
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+# and associated documentation files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.
+
+"""
+Script to run the examples given in the documenation (https://esr.readthedocs.io/en/latest/)
+"""
+
+import numpy as np
+import os
+import sys
+from mpi4py import MPI
+
+import esr.generation.duplicate_checker
+import esr.fitting.test_all
+import esr.fitting.test_all_Fisher
+import esr.fitting.match
+import esr.fitting.combine_DL
+import esr.fitting.plot
+from esr.fitting.likelihood import CCLikelihood, Likelihood, PoissonLikelihood
+from esr.fitting.fit_single import single_function
+import esr.plotting.plot
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+# Generate functions needed for examples
+runname = 'core_maths'
+for comp in range(1, 6):
+    esr.generation.duplicate_checker.main(runname, comp)
+
+# Fit the CC data with complexity 5 functions
+comp = 5
+likelihood = CCLikelihood()
+esr.fitting.test_all.main(comp, likelihood)
+esr.fitting.test_all_Fisher.main(comp, likelihood)
+esr.fitting.match.main(comp, likelihood)
+esr.fitting.combine_DL.main(comp, likelihood)
+esr.fitting.plot.main(comp, likelihood)
+
+# Define a custom likelihood class
+class GaussLikelihood(Likelihood):
+
+    def __init__(self, data_file, run_name, data_dir=None):
+        """Likelihood class used to fit a function directly using a Gaussian likelihood
+ 
+        """
+ 
+        super().__init__(data_file, data_file, run_name, data_dir=data_dir)
+        self.ylabel = r'$y$'    # for plotting
+        self.xvar, self.yvar, self.yerr = np.loadtxt(self.data_file, unpack=True)
+
+    def negloglike(self, a, eq_numpy, **kwargs):
+        """Negative log-likelihood for a given function.
+ 
+        Args:
+            :a (list): parameters to subsitute into equation considered
+            :eq_numpy (numpy function): function to use which gives y
+     
+        Returns:
+            :nll (float): - log(likelihood) for this function and parameters
+ 
+ 
+        """
+
+        ypred = self.get_pred(self.xvar, np.atleast_1d(a), eq_numpy)
+        if not np.all(np.isreal(ypred)):
+            return np.inf
+        nll = np.sum(0.5 * (ypred - self.yvar) ** 2 / self.yerr ** 2 + 0.5 * np.log(2 * np.pi) + np.log(self.yerr))
+        if np.isnan(nll):
+            return np.inf
+        return nll
+   
+# Run the Gaussian example
+np.random.seed(123)
+if rank == 0:
+    x = np.random.uniform(0.1, 5, 100)
+    y = 0.5 * x ** 2
+    yerr = np.full(x.shape, 1.0)
+    y = y + yerr * np.random.normal(size=len(x))
+    np.savetxt('data.txt', np.array([x, y, yerr]).T)
+sys.stdout.flush()
+comm.Barrier()
+likelihood = GaussLikelihood('data.txt', 'gauss_example', data_dir=os.getcwd())
+comm.Barrier()
+for comp in range(1, 6):
+    esr.fitting.test_all.main(comp, likelihood)
+    esr.fitting.test_all_Fisher.main(comp, likelihood)
+    esr.fitting.match.main(comp, likelihood)
+    esr.fitting.combine_DL.main(comp, likelihood)
+    esr.fitting.plot.main(comp, likelihood)
+
+# Run the Poisson examples
+np.random.seed(123)
+if rank == 0:
+    x = np.random.uniform(0.1, 5, 100)
+    y = 0.5 * x ** 2
+    yerr = np.full(x.shape, 0.1)
+    y = np.random.poisson(y)
+    np.savetxt('data.txt', np.array([x, y]).T)
+sys.stdout.flush()
+comm.Barrier()
+
+likelihood = PoissonLikelihood('data.txt', 'poisson_example', data_dir=os.getcwd())
+for comp in range(1, 6):
+    esr.fitting.test_all.main(comp, likelihood)
+    esr.fitting.test_all_Fisher.main(comp, likelihood)
+    esr.fitting.match.main(comp, likelihood)
+    esr.fitting.combine_DL.main(comp, likelihood)
+    esr.fitting.plot.main(comp, likelihood)
+
+# Plot the pareto front for the Poisson example
+if rank == 0:
+    print(likelihood.out_dir)
+    esr.plotting.plot.pareto_plot(likelihood.out_dir, 'pareto.png', do_DL=True, do_logL=True)
+    
+# Fit the CC data with a single function (LCDM)
+if rank == 0:
+    likelihood = CCLikelihood()
+    labels = ["+", "a0", "*", "a1", "pow", "x", "3"]
+    basis_functions = [["x", "a"],  # type0
+                    ["inv"],  # type1
+                    ["+", "*", "-", "/", "pow"]]  # type2
+
+    logl_lcdm_cc, dl_lcdm_cc = single_function(labels,
+                                                    basis_functions,
+                                                    likelihood,
+                                                    verbose=True)
+

--- a/examples/fit_from_string.py
+++ b/examples/fit_from_string.py
@@ -1,0 +1,106 @@
+# Copyright 2023 Deaglan J. Bartlett
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+# and associated documentation files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.
+
+"""
+Script to generate mock data according to some function and re-fit using the ESR
+single_function() function, defining the function as a string.
+"""
+
+import numpy as np
+import sympy
+import esr.generation.generator as generator
+import esr.generation.simplifier as simplifier
+from esr.fitting.fit_single import single_function
+from esr.fitting.likelihood import GaussLikelihood
+import os
+
+from esr.fitting.test_all import optimise_fun
+from esr.fitting.test_all_Fisher import convert_params
+
+def is_float(string):
+    try:
+        float(string)
+        return True
+    except ValueError:
+        return False
+
+# ESR hyperparams
+basis_functions = [["x", "a"],  # type0
+        ["inv"],  # type1
+        ["+", "*", "-", "/", "pow"]]  # type2
+maxvar = 20
+
+# Make some mock data and define likelihood
+np.random.seed(123)
+x = np.random.uniform(0.1, 5, 500)
+y = 1.1 * x ** 4 + 2 * x ** 3 + 4 * x ** 2 + 3 * x + 5
+yerr = np.full(x.shape, 1.0)
+y = y + yerr * np.random.normal(size=len(x))
+np.savetxt('data.txt', np.array([x, y, yerr]).T)
+likelihood = GaussLikelihood('data.txt', 'gauss_example', data_dir=os.getcwd())
+
+# Define all models
+all_models = ['1.1 * x ** 4 + 2 * x ** 3 + 4 * x ** 2 + 3 * x + 5']
+
+# Make string to sympy mapping
+x = sympy.symbols('x', real=True)
+a = sympy.symbols([f'a{i}' for i in range(maxvar)], real=True)
+d1 = {'x':x}
+d2 = {f'a{i}':a[i] for i in range(maxvar)}
+locs = {**d1, **d2}
+
+# Empty arrays to store results
+all_logl = np.empty(len(all_models))
+all_dl = np.empty(len(all_models))
+all_comp = np.empty(len(all_models))
+
+for i, fun in enumerate(all_models):
+
+    # Change string to list
+    expr, nodes, all_comp[i] = generator.string_to_node(fun, basis_functions, locs=locs, evalf=True)
+    labels = nodes.to_list(basis_functions)
+    
+    # Prepare to get parents
+    new_labels = [None] * len(labels)
+    for j, lab in enumerate(labels):
+        if lab == 'Mul':
+            new_labels[j] = '*'
+            labels[j] = '*'
+        elif lab == 'Add':
+            new_labels[j] = '+'
+            labels[j] = '+'
+        else:
+            new_labels[j] = lab.lower()
+            labels[j] = lab.lower()
+    param_idx = [j for j, lab in enumerate(new_labels) if is_float(lab)]
+    assert len(param_idx) <= maxvar
+    for k, j in enumerate(param_idx):
+        new_labels[j] = f'a{k}'
+
+    # Get parent operators
+    s = generator.labels_to_shape(new_labels, basis_functions)
+    success, _, tree = generator.check_tree(s)
+    parents = [None] + [labels[p.parent] for p in tree[1:]]
+    
+    # Replace floats with symbols (except exponents)
+    param_idx = [j for j, lab in enumerate(labels) if is_float(lab) and not (parents[j].lower() =='pow')]
+    for k, j in enumerate(param_idx):
+        labels[j] = f'a{k}'
+    fstr = generator.node_to_string(0, tree, labels)
+
+    all_logl[i], all_dl[i] = single_function(labels,
+                            basis_functions,
+                            likelihood,
+                            verbose=False)
+                            
+    print(expr)
+    print('\t-logL', all_logl[-1])
+    print('\tL(D)', all_dl[-1])


### PR DESCRIPTION
Previously, functions which needed more than 4 parameters could not be fitted with ESR. This is restrictive if one uses complexities greater than 10, and also if one wants to fit an arbitrary function with the code. This has now been removed, and the output files can have a varying number of columns now, depending on the number of parameters. The files that read and write these automatically determine the number of columns/parameters needed. The old file style with 4 parameters is still enforced for complexities <= 10 for backwards compatibility.