### PR TITLE
Not optimising repeated functions

### DIFF
--- a/esr/fitting/match.py
+++ b/esr/fitting/match.py
@@ -162,7 +162,8 @@ def main(comp, likelihood, tmax=5, print_frequency=1000, try_integration=False):
                 for r in reversed(range(1, len(try_idx))):
                     for idx in itertools.combinations(try_idx, r):
                         p = np.copy(ptrue)
-                        p[idx] = 0.
+                        for idx_ in idx:
+                            p[idx_] = 0.
                         if k==1:
                             negloglike_all[i] = f1(p)               # Modified here for this variant, but if this doesn't happen it stays the same as the unique eq
                         else:

--- a/esr/fitting/test_all.py
+++ b/esr/fitting/test_all.py
@@ -102,7 +102,7 @@ def get_functions(comp, likelihood, unique=True):
     return fcn_list[data_start:data_end], data_start, data_end
     
     
-def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, previous_fns=[], try_integration=False, log_opt=False, max_param=4, Niter_params=[40,60], Nconv_params=[-5,20], test_success=False):
+def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, comp=0, try_integration=False, log_opt=False, max_param=4, Niter_params=[40,60], Nconv_params=[-5,20], test_success=False):
     """Optimise the parameters of a function to fit data
     
     The list of parameters, P, passed as Niter_params and Nconv_params compute these values, N, to be
@@ -116,7 +116,7 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, previous_fns=[], try_integ
         :tmax (float): maximum time in seconds to run any one part of simplification procedure for a given function
         :pmin (float): minimum value for each parameter to consider when generating initial guess
         :pmax (float): maximum value for each parameter to consider when generating initial guess
-        :previous_fns (list, default=[]): All unique equations up to current complexity to check for duplicates at this complexity
+        :comp (float, default=0): Complexity. Deafault of 0 because it is not provided when fitting a single function
         :try_integration (bool, default=False): when likelihood requires integral, whether to try to analytically integrate (True) or just numerically integrate (False)
         :log_opt (bool, default=False): whether to optimise 1 and 2 parameter cases in log space
         :max_param (int, default=4): The maximum number of parameters considered. This sets the shapes of arrays used.
@@ -135,9 +135,14 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, previous_fns=[], try_integ
     nparam = simplifier.count_params([fcn_i], max_param)[0]
     params = np.zeros(max_param)
 
-    if fcn_i in previous_fns:
-        return np.inf, params
-    
+    if comp>1:
+        previous_fns_file = likelihood.fn_dir + "/compl_"+str(comp)+"/previous_eqns_"+str(comp)+".txt"
+        with open(previous_fns_file, "r") as f:
+            previous_fns = f.readlines()
+        # discard repeat of lower complexity (e.g. [inv, inv, ...])
+        if fcn_i in previous_fns:
+            return np.inf, params
+            
     Niter = int(np.sum(nparam ** np.arange(len(Niter_params)) * np.array(Niter_params)))
     Nconv = int(np.sum(nparam ** np.arange(len(Nconv_params)) * np.array(Nconv_params)))
     if (Nconv <= 0) or (Niter <= 0) or (Nconv > Niter):
@@ -339,13 +344,19 @@ def main(comp, likelihood, tmax=5, pmin=0, pmax=3, print_frequency=50, try_integ
     fcn_list_proc, _, _ = get_functions(comp, likelihood)
 
     
-    previous_unifn_list = []
-    if comp>1: 
-        for compl in range(1,comp):
-            unifn_file_i = likelihood.fn_dir + "/compl_%i/unique_equations_%i.txt"%(compl,compl)
-            with open(unifn_file_i, "r") as f:
-                fcn_list_compl = f.readlines()
-            previous_unifn_list += fcn_list_compl
+    if rank==0:
+        previous_unifn_list = []
+        if comp>1: 
+            for compl in range(1,comp):
+                unifn_file_i = likelihood.fn_dir + "/compl_%i/unique_equations_%i.txt"%(compl,compl)
+                with open(unifn_file_i, "r") as f:
+                    fcn_list_i = f.readlines()
+                previous_unifn_list += fcn_list_i
+        previous_unifn_list = np.array(previous_unifn_list)
+        np.savetxt(likelihood.fn_dir + "/compl_"+str(comp)+"/previous_eqns_"+str(comp)+".txt", previous_unifn_list, fmt='%s')
+
+    comm.Barrier()
+
     
     # Set max param >=4 for backwards compatibility
     max_param = int(max(4, np.floor((comp - 1) / 2)))
@@ -363,7 +374,7 @@ def main(comp, likelihood, tmax=5, pmin=0, pmax=3, print_frequency=50, try_integ
                                                     tmax, 
                                                     pmin, 
                                                     pmax, 
-                                                    previous_fns=previous_unifn_list,
+                                                    comp=comp,
                                                     try_integration=try_integration,
                                                     log_opt=log_opt,
                                                     max_param=max_param,
@@ -376,7 +387,7 @@ def main(comp, likelihood, tmax=5, pmin=0, pmax=3, print_frequency=50, try_integ
                                                     tmax, 
                                                     pmin, 
                                                     pmax, 
-                                                    previous_fns=previous_unifn_list,
+                                                    comp=comp,
                                                     try_integration=False,
                                                     log_opt=log_opt,
                                                     max_param=max_param,

--- a/esr/fitting/test_all.py
+++ b/esr/fitting/test_all.py
@@ -102,7 +102,7 @@ def get_functions(comp, likelihood, unique=True):
     return fcn_list[data_start:data_end], data_start, data_end
     
     
-def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log_opt=False, max_param=4, Niter_params=[40,60], Nconv_params=[-5,20], test_success=False):
+def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, previous_fns=[], try_integration=False, log_opt=False, max_param=4, Niter_params=[40,60], Nconv_params=[-5,20], test_success=False):
     """Optimise the parameters of a function to fit data
     
     The list of parameters, P, passed as Niter_params and Nconv_params compute these values, N, to be
@@ -116,6 +116,7 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log
         :tmax (float): maximum time in seconds to run any one part of simplification procedure for a given function
         :pmin (float): minimum value for each parameter to consider when generating initial guess
         :pmax (float): maximum value for each parameter to consider when generating initial guess
+        :previous_fns (list, default=[]): All unique equations up to current complexity to check for duplicates at this complexity
         :try_integration (bool, default=False): when likelihood requires integral, whether to try to analytically integrate (True) or just numerically integrate (False)
         :log_opt (bool, default=False): whether to optimise 1 and 2 parameter cases in log space
         :max_param (int, default=4): The maximum number of parameters considered. This sets the shapes of arrays used.
@@ -133,6 +134,9 @@ def optimise_fun(fcn_i, likelihood, tmax, pmin, pmax, try_integration=False, log
     
     nparam = simplifier.count_params([fcn_i], max_param)[0]
     params = np.zeros(max_param)
+
+    if fcn_i in previous_fns:
+        return np.inf, params
     
     Niter = int(np.sum(nparam ** np.arange(len(Niter_params)) * np.array(Niter_params)))
     Nconv = int(np.sum(nparam ** np.arange(len(Nconv_params)) * np.array(Nconv_params)))
@@ -333,6 +337,15 @@ def main(comp, likelihood, tmax=5, pmin=0, pmax=3, print_frequency=50, try_integ
         print('\nRunning fits', flush=True)
 
     fcn_list_proc, _, _ = get_functions(comp, likelihood)
+
+    
+    previous_unifn_list = []
+    if comp>1: 
+        for compl in range(1,comp):
+            unifn_file_i = likelihood.fn_dir + "/compl_%i/unique_equations_%i.txt"%(compl,compl)
+            with open(unifn_file_i, "r") as f:
+                fcn_list_compl = f.readlines()
+            previous_unifn_list += fcn_list_compl
     
     # Set max param >=4 for backwards compatibility
     max_param = int(max(4, np.floor((comp - 1) / 2)))
@@ -350,6 +363,7 @@ def main(comp, likelihood, tmax=5, pmin=0, pmax=3, print_frequency=50, try_integ
                                                     tmax, 
                                                     pmin, 
                                                     pmax, 
+                                                    previous_fns=previous_unifn_list,
                                                     try_integration=try_integration,
                                                     log_opt=log_opt,
                                                     max_param=max_param,
@@ -362,6 +376,7 @@ def main(comp, likelihood, tmax=5, pmin=0, pmax=3, print_frequency=50, try_integ
                                                     tmax, 
                                                     pmin, 
                                                     pmax, 
+                                                    previous_fns=previous_unifn_list,
                                                     try_integration=False,
                                                     log_opt=log_opt,
                                                     max_param=max_param,

--- a/esr/fitting/test_all_Fisher.py
+++ b/esr/fitting/test_all_Fisher.py
@@ -204,7 +204,8 @@ def convert_params(fcn_i, eq, integrated, theta_ML, likelihood, negloglike, max_
             for r in reversed(range(1, len(try_idx))):
                 for idx in itertools.combinations(try_idx, r):
                     theta_ML = np.copy(theta_ML_orig)
-                    theta_ML[idx] = 0.
+                    for idx_ in idx:
+                        theta_ML[idx_] = 0.
                     negloglike = fop(theta_ML)
                     if np.isfinite(negloglike):
                         break


### PR DESCRIPTION
We create a file with all unique equations from all complexities previous to the one being evaluated, and if a function about to have its parameters optimised has an exact match in that file, we set its log likelihood to infinity so that it is discarded. This is both to save time in the optimisation and to not have the exact same function in different final_compl.dat files, since we only care about the lower complexity representation.