### PR TITLE
55 typo in generator function

### DIFF
--- a/esr/generation/generator.py
+++ b/esr/generation/generator.py
@@ -183,7 +183,7 @@ class DecoratedNode:
         elif self.op == "Pow" and (self.children[1].val == str(2)) and "square" in basis_functions[1]:
             return ["square"] + self.children[0].to_list(basis_functions)
         # pow(x,2) instead of Square(x) if necessary
-        elif self.op == "Square" and "sqaure" not in basis_functions[1]:
+        elif self.op == "Square" and "square" not in basis_functions[1]:
             return ["pow"] + self.children[0].to_list(basis_functions) + ["2"]
         #  Cube(x) instead of pow(x, 3)
         elif self.op == "Pow" and (self.children[1].val == str(3)) and "cube" in basis_functions[1]:

--- a/tests/test_esr.py
+++ b/tests/test_esr.py
@@ -219,7 +219,7 @@ def test_function_making():
 def test_node():
 
     labels = ["-", "+", "/", "+", "+", "a0", "*", "a1", "pow", "x",
-              "3", "*", "a2", "pow", "x", "2", "*", "a3", "x", "pow", "x", "0.5",
+              "3", "*", "a2", "pow", "x", "2.1", "*", "a3", "x", "pow", "x", "0.5",
               "*", "a4", "pow", "x", "-1"]
     basis_functions = [["x", "a"],  # type0
                        ["inv"],  # type1
@@ -264,6 +264,9 @@ def test_node():
     assert unit_nodes.is_unity()
 
     # Test counting
+    print(nodes.count_nodes(basis_functions))
+    print(len(labels))
+    print(labels)
     assert nodes.count_nodes(basis_functions) == len(labels)
     mylist = nodes.to_list(basis_functions)
     assert len(mylist) == len(labels)

--- a/tests/test_esr.py
+++ b/tests/test_esr.py
@@ -264,9 +264,6 @@ def test_node():
     assert unit_nodes.is_unity()
 
     # Test counting
-    print(nodes.count_nodes(basis_functions))
-    print(len(labels))
-    print(labels)
     assert nodes.count_nodes(basis_functions) == len(labels)
     mylist = nodes.to_list(basis_functions)
     assert len(mylist) == len(labels)


### PR DESCRIPTION
This pull request fixes a typo in a code identifier. Corrected the spelling of "square" in the `to_list` method of `generator.py` to ensure the code checks for the correct basis function name.