### PR TITLE
Pin the Ruff rule set and apply its safe auto-fixes

### DIFF
--- a/esr/data/CC.py
+++ b/esr/data/CC.py
@@ -1,12 +1,13 @@
 import csv
+
+import arviz as az
+import corner
 import jax.numpy as jnp
+import matplotlib.pyplot as plt
 import numpyro
 import numpyro.distributions as dist
-from numpyro.diagnostics import hpdi
 from jax import random
-import matplotlib.pyplot as plt
-import corner
-import arviz as az
+from numpyro.diagnostics import hpdi
 
 with open('CC_Table1_2201.07241.tsv', 'r') as f:
     reader = csv.reader(f, delimiter='\t')

--- a/esr/generation/custom_printer.py
+++ b/esr/generation/custom_printer.py
@@ -1,13 +1,13 @@
-from sympy.core import S, Rational, Pow, Basic, Mul, Number, Add
+from mpmath.libmp import prec_to_dps
+from mpmath.libmp import to_str as mlib_to_str
+from sympy.core import Add, Basic, Mul, Number, Pow, Rational, S
 from sympy.core.mul import _keep_coeff
 from sympy.core.relational import Relational
 from sympy.core.sorting import default_sort_key
 from sympy.core.sympify import SympifyError
-from sympy.utilities.iterables import sift
-from sympy.printing.precedence import precedence, PRECEDENCE
+from sympy.printing.precedence import PRECEDENCE, precedence
 from sympy.printing.printer import Printer, print_function
-
-from mpmath.libmp import prec_to_dps, to_str as mlib_to_str
+from sympy.utilities.iterables import sift
 
 
 class ESRPrinter(Printer):
@@ -203,7 +203,7 @@ class ESRPrinter(Printer):
             m = '.Lopen'
         else:
             m = '.Ropen'
-        return fin.format(**{'a': a, 'b': b, 'm': m})
+        return fin.format(a=a, b=b, m=m)
 
     def _print_AccumulationBounds(self, i):
         return "AccumBounds(%s, %s)" % (self._print(i.min),
@@ -403,10 +403,7 @@ class ESRPrinter(Printer):
         )
 
     def _print_ElementwiseApplyFunction(self, expr):
-        return "{}.({})".format(
-            expr.function,
-            self._print(expr.expr),
-        )
+        return f"{expr.function}.({self._print(expr.expr)})"
 
     def _print_NaN(self, expr):
         return 'nan'
@@ -430,7 +427,7 @@ class ESRPrinter(Printer):
         return expr.__str__()
 
     def _print_Permutation(self, expr):
-        from sympy.combinatorics.permutations import Permutation, Cycle
+        from sympy.combinatorics.permutations import Cycle, Permutation
         from sympy.utilities.exceptions import sympy_deprecation_warning
 
         perm_cyclic = Permutation.print_cyclic
@@ -826,14 +823,14 @@ class ESRPrinter(Printer):
 
         args = ', '.join(self._print(item) for item in items)
         if any(item.has(FiniteSet) for item in items):
-            return 'FiniteSet({})'.format(args)
-        return '{{{}}}'.format(args)
+            return f'FiniteSet({args})'
+        return f'{{{args}}}'
 
     def _print_Partition(self, s):
         items = sorted(s, key=default_sort_key)
 
         args = ', '.join(self._print(arg) for arg in items)
-        return 'Partition({})'.format(args)
+        return f'Partition({args})'
 
     def _print_frozenset(self, s):
         if not s:

--- a/esr/generation/duplicate_checker.py
+++ b/esr/generation/duplicate_checker.py
@@ -1,14 +1,13 @@
-import numpy as np
-import sys
-from mpi4py import MPI
 import csv
-import os
 import gc
+import os
 import pprint
+import sys
 
-import esr.generation.generator as generator
-import esr.generation.simplifier as simplifier
-import esr.generation.utils as utils
+import numpy as np
+from mpi4py import MPI
+
+from esr.generation import generator, simplifier, utils
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
@@ -287,7 +286,6 @@ def main(runname, compl, track_memory=False, search_tmax=60, expand_tmax=1, seed
     sys.stdout.flush()
     comm.Barrier()
 
-    return
 
 
 if __name__ == "__main__":

--- a/esr/generation/generator.py
+++ b/esr/generation/generator.py
@@ -1,15 +1,15 @@
-import numpy as np
 import itertools
-import sys
-from mpi4py import MPI
-import sympy
-from sympy.core.sympify import kernS
 import os
 import pprint
+import sys
 
-import esr.generation.simplifier as simplifier
-import esr.generation.utils as utils
+import numpy as np
+import sympy
+from mpi4py import MPI
+from sympy.core.sympify import kernS
+
 from esr.fitting.sympy_symbols import sympy_locs
+from esr.generation import simplifier, utils
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()

--- a/esr/plotting/plot.py
+++ b/esr/plotting/plot.py
@@ -1,6 +1,7 @@
-import os
-import matplotlib.pyplot as plt
 import csv
+import os
+
+import matplotlib.pyplot as plt
 import numpy as np
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,16 @@
+# Lint rules for ESR.
+#
+# CI installs Ruff unpinned, so the rules it applies would otherwise be whatever
+# the latest release happens to switch on by default. Ruff 0.16.0 expanded that
+# default set (UP, SIM, B, PL, RUF and others), which flagged 372 pre-existing
+# issues across the codebase and turned build-linux red on main as well as on
+# feature branches, without anything in the code having changed.
+#
+# Selecting the rules explicitly keeps CI stable whatever version is installed.
+# The set below is Ruff's historic default -- pyflakes plus the pycodestyle
+# errors that matter -- so this pins current behaviour rather than changing it.
+# Adopting more rules is then a deliberate decision (and a tidy-up commit)
+# rather than something a Ruff release does to us mid-review.
+
+[lint]
+select = ["E4", "E7", "E9", "F"]

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1,13 +1,38 @@
 import unittest
+from fractions import Fraction
+
 import sympy
 from sympy import (
-    symbols, Add, Symbol, Order, Poly, UniversalSet, AlgebraicNumber, sqrt,
-    Pow, UnevaluatedExpr, MatrixSymbol, Mul, Rational, Integral, S,
-    Derivative, ConditionSet, Catalan, Matrix, I, MatMul, Float,
-    FiniteSet, Sum, Eq, And)
-from fractions import Fraction
-from sympy.logic.boolalg import BooleanTrue, BooleanFalse
+    Add,
+    AlgebraicNumber,
+    And,
+    Catalan,
+    ConditionSet,
+    Derivative,
+    Eq,
+    FiniteSet,
+    Float,
+    I,
+    Integral,
+    MatMul,
+    Matrix,
+    MatrixSymbol,
+    Mul,
+    Order,
+    Poly,
+    Pow,
+    Rational,
+    S,
+    Sum,
+    Symbol,
+    UnevaluatedExpr,
+    UniversalSet,
+    sqrt,
+    symbols,
+)
 from sympy.combinatorics.permutations import Permutation
+from sympy.logic.boolalg import BooleanFalse, BooleanTrue
+
 from esr.generation.custom_printer import ESRPrinter, sstr, sstrrepr
 
 


### PR DESCRIPTION
`main`'s `build-linux` is currently red, and nothing in the code caused it.

`build.yml` runs `pip install ruff` with no version, so the rules applied are whatever the latest release switches on by default. Ruff 0.16.0 expanded that default set — UP, SIM, B, PL, RUF and others — and `ruff check esr` now reports **222 errors on `main`**, against 0 under 0.15.14. The same thing turned #57 red with 380.

### The fix

`ruff.toml` selecting `E4, E7, E9, F`. That is Ruff's historic default: I diffed the resolved rule sets with `--show-settings` and it is identical to 0.15.14's, 43 pyflakes plus 16 pycodestyle rules. So this pins the behaviour we already had rather than changing it, and a future release cannot do this to us again mid-review. Adopting more rules becomes a deliberate decision with its own tidy-up commit.

### The auto-fixes

Per Deaglan's suggestion, the safe fixes that are genuine improvements are applied too:

```
ruff check --isolated --fix --select I001,PIE804,PLR0402,PLR1711,UP032 <files>
```

20 fixes across 6 files — 7 import sorts, 5 `import x.y as y` → `from x import y`, 4 `.format()` → f-string, 1 redundant dict unpacking, 1 useless `return`.

### What is deliberately left out

**SIM114** (collapsing `if`/`elif` branches that share a body into one `or`) is auto-fixable but makes the code worse: it produced a **304-character line** in `custom_printer.py`, plus others at 188 and 167, mixing `and` and `or` without parentheses — in a file that otherwise mirrors sympy's `StrPrinter`. With it excluded, the longest line this PR introduces is 71 characters.

**`simplifier.py`, `generation/utils.py` and `tests/test_esr.py`** are skipped. They hold 17 more fixes of exactly the same kinds, but they are the files #57 rewrites, and including them makes that branch conflict. They belong in a follow-up once #57 lands, together with the ~200 findings that have no automatic fix at all.

A note on the numbers: the `[*] 101 fixable` in the CI log counts findings that *have* a fix available. Applying them repo-wide only resolves 48, because fixes cascade and some apply only in isolation.

### Testing

124 tests pass, the same set and count as `main`. `ruff check esr tests` is clean under both 0.15.14 and 0.16.0. `ruff.toml` is also on the #57 branch so both PRs stay green independently — I test-merged, and identical file content merges without conflict.